### PR TITLE
fix: create directories program start

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -83,3 +83,10 @@ func SanitizeString(s string) string {
 	}
 	return re.ReplaceAllString(s, "_")
 }
+
+func CreateDirs(p string) error {
+	if err := os.MkdirAll(p, 0750); err != nil && !os.IsExist(err) {
+		log.Fatalf("Couldn't create data directory because %v. Exiting... ", err)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -43,10 +43,11 @@ func main() {
 		}
 	}
 	files := make([]*os.File, len(cli.CLI.Stocks))
-	// create data directory
-	if _, err := os.Stat("data"); os.IsNotExist(err) {
-		if err := os.Mkdir("data", 0600); err != nil {
-			log.Fatalf("Couldn't create data directory because %v. Exiting... ", err)
+	dirs := []string{"data/rolling", "data/candlesticks"}
+	for _, dir := range dirs {
+		err := internal.CreateDirs(dir)
+		if err != nil {
+			log.Fatalf("Couldn't create directories. %v", err)
 		}
 	}
 	createFiles(mapper, syncMap)


### PR DESCRIPTION
This checks if the needed directories are already created and if not creates them on program initialization. If path is already a directory, os.MkdirAll does nothing and returns nil. 