### PR TITLE
Add rolling mean data

### DIFF
--- a/internal/mean.go
+++ b/internal/mean.go
@@ -1,0 +1,84 @@
+package internal
+
+import (
+	"encoding/csv"
+	"errors"
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+type MeanStockData struct {
+	TotalTransactions int
+	MeanPrice         float64
+	StockSymbol       string
+	StartTime         time.Time
+	EndTime           time.Time
+}
+
+func CalculateMeanStockData(t []Data, s, e time.Time) *MeanStockData {
+	return &MeanStockData{
+		TotalTransactions: len(t),
+		StockSymbol:       t[0].Symbol,
+		MeanPrice:         getMeanPrice(t),
+		StartTime:         s.Truncate(1 * time.Minute),
+		EndTime:           e.Truncate(1 * time.Minute),
+	}
+}
+
+func getMeanPrice(p []Data) (mean float64) {
+	sum := 0.0
+	for _, v := range p {
+		sum += v.Price
+	}
+	return sum / float64(len(p))
+}
+
+func (m *MeanStockData) toSlice() []string {
+	s := SanitizeString(m.StockSymbol)
+	return []string{
+		s,
+		m.StartTime.String(),
+		m.EndTime.String(),
+		strconv.FormatFloat(m.MeanPrice, 'f', -1, 64),
+		strconv.FormatInt(int64(m.TotalTransactions), 10),
+	}
+}
+func (m *MeanStockData) getHeaders() []string {
+	return []string{"Symbol", "StartTime", "EndTime", "MeanPrice", "Transactions"}
+}
+
+func (m *MeanStockData) WriteToDisk(f *os.File) error {
+	w := csv.NewWriter(f)
+	s := m.toSlice()
+	err := w.Write(s)
+	if err != nil {
+		return err
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+func (m *MeanStockData) WriteHeaders(file *os.File) error {
+	if file == nil {
+		return errors.New("file handler cannot be nil")
+	}
+	if IsFileEmpty(file) {
+		w := csv.NewWriter(file)
+		if bytes, _ := file.Read([]byte{}); bytes == 0 {
+			err := w.Write(m.getHeaders())
+			if err != nil {
+				return err
+			}
+		}
+		w.Flush()
+		if err := w.Error(); err != nil {
+			log.Fatal(err)
+		}
+	}
+	return nil
+}

--- a/internal/stockHandle.go
+++ b/internal/stockHandle.go
@@ -10,21 +10,26 @@ import (
 )
 
 type StockHandle struct {
-	RollingFile     *os.File
-	CandlestickFile *os.File
-	OnceFlag        *sync.Once
-	StockChannel    chan time.Time
+	RollingFile        *os.File
+	CandlestickFile    *os.File
+	MeanFile           *os.File
+	OnceFlag           *sync.Once
+	StockChannel       chan time.Time
+	RollingMeanChannel chan time.Time
 }
 
 func InitializeMapper(mapper map[string]*StockHandle) {
 	for _, v := range cli.CLI.Stocks {
 		f, s := createRollingFile(v)
 		c := createCandlestickFile(v)
+		m := createMeanFile(v)
 		mapper[v] = &StockHandle{
-			RollingFile:     f,
-			CandlestickFile: c,
-			OnceFlag:        s,
-			StockChannel:    make(chan time.Time, 100),
+			RollingFile:        f,
+			CandlestickFile:    c,
+			MeanFile:           m,
+			OnceFlag:           s,
+			StockChannel:       make(chan time.Time, 100),
+			RollingMeanChannel: make(chan time.Time, 100),
 		}
 	}
 }
@@ -70,14 +75,36 @@ func createCandlestickFile(stock string) *os.File {
 	} else if err != nil {
 		log.Fatalf("Couln't create file %v", err)
 	}
-	defer writeCstickHeaders(file)
+	defer writeHeaders(file, &CandleStick{})
 	return file
 }
 
-func writeCstickHeaders(file *os.File) {
+func createMeanFile(stock string) *os.File {
+	var (
+		file *os.File
+		err  error
+	)
+	safeStock := SanitizeString(stock)
+	file, err = os.OpenFile("data/mean/"+safeStock+".csv", os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0660)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		file, err = os.Create("data/mean/" + safeStock + ".csv")
+		if errors.Is(err, os.ErrPermission) {
+			log.Fatalf("Cannot create a file due to permission reasons")
+			return nil
+		} else {
+			log.Fatalf("Couldn't create the file")
+			return nil
+		}
+	} else if err != nil {
+		log.Fatalf("Couln't create file %v", err)
+	}
+	defer writeHeaders(file, &MeanStockData{})
+	return file
+}
+
+func writeHeaders(file *os.File, c CSVAble) {
 	if IsFileEmpty(file) {
-		cs := &CandleStick{}
-		err := cs.WriteHeaders(file)
+		err := c.WriteHeaders(file)
 		if err != nil {
 			log.Fatalf("Write headers failed due to %v", err.Error())
 		}

--- a/internal/stockHandle.go
+++ b/internal/stockHandle.go
@@ -1,0 +1,85 @@
+package internal
+
+import (
+	"errors"
+	cli "finnhub-stock-analysis-go/cmd"
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+type StockHandle struct {
+	RollingFile     *os.File
+	CandlestickFile *os.File
+	OnceFlag        *sync.Once
+	StockChannel    chan time.Time
+}
+
+func InitializeMapper(mapper map[string]*StockHandle) {
+	for _, v := range cli.CLI.Stocks {
+		f, s := createRollingFile(v)
+		c := createCandlestickFile(v)
+		mapper[v] = &StockHandle{
+			RollingFile:     f,
+			CandlestickFile: c,
+			OnceFlag:        s,
+			StockChannel:    make(chan time.Time, 100),
+		}
+	}
+}
+
+func createRollingFile(stock string) (*os.File, *sync.Once) {
+	var (
+		file *os.File
+		err  error
+	)
+	safeStock := SanitizeString(stock)
+	file, err = os.OpenFile("data/rolling/"+safeStock+".csv", os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0660)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		file, err = os.Create("data/rolling/" + safeStock + ".csv")
+		if errors.Is(err, os.ErrPermission) {
+			log.Fatalf("Cannot create a file due to permission reasons")
+			return nil, nil
+		} else {
+			log.Fatalf("Couldn't create the file")
+			return nil, nil
+		}
+	} else if err != nil {
+		log.Fatalf("Couln't create file %v", err)
+	}
+	return file, &sync.Once{}
+}
+
+func createCandlestickFile(stock string) *os.File {
+	var (
+		file *os.File
+		err  error
+	)
+	safeStock := SanitizeString(stock)
+	file, err = os.OpenFile("data/candlesticks/"+safeStock+".csv", os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0660)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		file, err = os.Create("data/candlesticks/" + safeStock + ".csv")
+		if errors.Is(err, os.ErrPermission) {
+			log.Fatalf("Cannot create a file due to permission reasons")
+			return nil
+		} else {
+			log.Fatalf("Couldn't create the file")
+			return nil
+		}
+	} else if err != nil {
+		log.Fatalf("Couln't create file %v", err)
+	}
+	defer writeCstickHeaders(file)
+	return file
+}
+
+func writeCstickHeaders(file *os.File) {
+	if IsFileEmpty(file) {
+		cs := &CandleStick{}
+		err := cs.WriteHeaders(file)
+		if err != nil {
+			log.Fatalf("Write headers failed due to %v", err.Error())
+		}
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -63,15 +63,15 @@ func FindItems(f string, t *time.Time) []Data {
 	return data[:offset]
 }
 
-func WaitForCandlestick(f *os.File, in chan time.Time, cstick *os.File) {
+func WaitForCandlestick(stock *StockHandle) {
 	for {
-		tm := <-in
-		items := FindItems(f.Name(), &tm)
+		tm := <-stock.StockChannel
+		items := FindItems(stock.RollingFile.Name(), &tm)
 		if len(items) == 0 || items == nil {
 			log.Println("Cannot calculate candlestick when there is no data")
 		} else {
 			cs := CalculateCandlestick(items)
-			_ = cs.WriteToDisk(cstick)
+			_ = cs.WriteToDisk(stock.CandlestickFile)
 		}
 	}
 }


### PR DESCRIPTION
Currently, this refactors the application to make feature scalability easier. It removes all the different maps in favor of one map which holds a new struct that holds the file descriptors, the initialization once flags and the channels of communication for each stock symbol. It also moves the file creation logic to the internal package. 

To represent the rolling mean candlestick, I created the `MeanStockData` struct  
```golang
type MeanStockData struct {
	TotalTransactions int
	MeanPrice         float64
	StockSymbol       string
	StartTime         time.Time
	EndTime           time.Time
}
```
which implements the CSVAble interface to enable writing data to file.

I also added 2 new fields to the `StockHandle` struct
```
type StockHandle struct {
        ...
	MeanFile           *os.File
        ...
	RollingMeanChannel chan time.Time
}
```
to hold the file descriptor for the mean file and the channel to which the main process will write every minute in order for the receiving end to calculate the mean stock price. 